### PR TITLE
Change modelling from `timing + topic` to `timing + resourcing source`

### DIFF
--- a/design-doctorine.md
+++ b/design-doctorine.md
@@ -1,3 +1,10 @@
-* separate the questionnaires based on timing + topic
-* stay on top of errors and warnings: QA report should always say 0 warnings and 0 errors
+# Modelling
+* separate the questionnaires based on timing + reporting source
+  * .fsh file layout will follow from that
+* use groups to mark differences in categories
+* enforce PROM best practice rendering guidelines
+  * (these need to be created by ICHOM first)
+
+# Tooling
+* stay on top of errors and warnings: both SUSHI and publisher's QA report should always say 0 warnings and 0 errors
 * keep IG publisher and sushi up to date - always use the latest version


### PR DESCRIPTION
Change modelling from `timing + topic` to `timing + resourcing source` per instructions from clinicians. Groups are necessary as well now so added a note for that.